### PR TITLE
Enable the PullRequestHandler for more PR types

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,6 @@
 on:
   pull_request:
-    types: [opened]
+    types: [opened, reopened, edited]
 name: Pull Requests
 jobs:
   pullRequestHandler:


### PR DESCRIPTION
The PullRequestHandler only runs on PR creation currently. I'm updating it so that it runs when reopened and edited.