### PR TITLE
Dive: Added Dive 0.13.0 with ARM64 support

### DIFF
--- a/bucket/dive.json
+++ b/bucket/dive.json
@@ -1,0 +1,24 @@
+{
+    "version": "0.12.0",
+    "description": "A tool for exploring each layer in a docker image.",
+    "homepage": "https://github.com/wagoodman/dive/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/wagoodman/dive/releases/download/v0.12.0/dive_0.12.0_windows_amd64.zip",
+            "hash": "b60d750852543e5a4b38c42590e2036aa2a8026cdb14d835090399f5e1312192"
+        }
+    },
+    "bin": "dive.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/wagoodman/dive/releases/download/v$version/dive_$version_windows_amd64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/dive_$version_checksums.txt"
+        }
+    }
+}

--- a/bucket/dive.json
+++ b/bucket/dive.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.12.0",
+    "version": "0.13.0",
     "description": "A tool for exploring each layer in a docker image.",
     "homepage": "https://github.com/wagoodman/dive/",
     "license": "MIT",
     "architecture": {
         "arm64": {
-            "url": "https://github.com/wagoodman/dive/releases/download/v0.12.0/dive_0.12.0_windows_arm64.zip",
-            "hash": "fd066066f4be5cd0e51773fbe1721587ee2ad70d258932b05c1cf654d9bb57ad"
+            "url": "https://github.com/wagoodman/dive/releases/download/v0.13.0/dive_0.13.0_windows_arm64.zip",
+            "hash": "4ad69a7e4a973611a0894698583519b726effb537dd0d0d53e7ebd626032514e"
         },
         "64bit": {
-            "url": "https://github.com/wagoodman/dive/releases/download/v0.12.0/dive_0.12.0_windows_amd64.zip",
-            "hash": "b60d750852543e5a4b38c42590e2036aa2a8026cdb14d835090399f5e1312192"
+            "url": "https://github.com/wagoodman/dive/releases/download/v0.13.0/dive_0.13.0_windows_amd64.zip",
+            "hash": "acaeaff808b5afcaaa86d024a20b85e3dfc43944faa7e1046587ebc5a5b1b912"
         }
     },
     "bin": "dive.exe",

--- a/bucket/dive.json
+++ b/bucket/dive.json
@@ -4,6 +4,10 @@
     "homepage": "https://github.com/wagoodman/dive/",
     "license": "MIT",
     "architecture": {
+        "arm64": {
+            "url": "https://github.com/wagoodman/dive/releases/download/v0.12.0/dive_0.12.0_windows_arm64.zip",
+            "hash": "fd066066f4be5cd0e51773fbe1721587ee2ad70d258932b05c1cf654d9bb57ad"
+        },
         "64bit": {
             "url": "https://github.com/wagoodman/dive/releases/download/v0.12.0/dive_0.12.0_windows_amd64.zip",
             "hash": "b60d750852543e5a4b38c42590e2036aa2a8026cdb14d835090399f5e1312192"
@@ -13,6 +17,9 @@
     "checkver": "github",
     "autoupdate": {
         "architecture": {
+            "arm64": {
+                "url": "https://github.com/wagoodman/dive/releases/download/v$version/dive_$version_windows_arm64.zip"
+            },
             "64bit": {
                 "url": "https://github.com/wagoodman/dive/releases/download/v$version/dive_$version_windows_amd64.zip"
             }


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

This change adds the manifest for Dive 0.13.0 with ARM64 support. The manifest initially came from <https://github.com/ScoopInstaller/Main/blob/master/bucket/dive.json>. I started with 0.12.0, added arm64 support, and then used CheckVer.ps1 to update to 0.13.0.
